### PR TITLE
Fix KeyError when 'owner' attribute is missing in project data

### DIFF
--- a/pyoverleaf/_webapi.py
+++ b/pyoverleaf/_webapi.py
@@ -41,7 +41,7 @@ class Project:
     source: str
     archived: bool
     trashed: bool
-    owner: User
+    owner: Optional[User] = None
     last_updated_by: Optional[User] = None
 
     @classmethod
@@ -54,11 +54,16 @@ class Project:
             source=data["source"],
             archived=data["archived"],
             trashed=data["trashed"],
-            owner=User.from_data(data["owner"]),
         )
 
-        if "lastUpdatedBy" in data:
-            out.last_updated_by = User.from_data(data["lastUpdatedBy"]),
+        owner_data = data.get("owner")
+        if owner_data is not None:
+            out.owner = User.from_data(owner_data)
+
+        last_updated_by_data = data.get("lastUpdatedBy")
+        if last_updated_by_data is not None:
+            out.last_updated_by = User.from_data(last_updated_by_data)
+
         return out
 
 


### PR DESCRIPTION
For projects that are shared by others **with read-only access**, the 'owner' attribute is not present in the project data. This causes a KeyError when trying to access 'owner' in the 'from_data' method of the 'Project' class.

This pull request fixes the error by checking the presence of the 'owner' attribute in the project data before accessing it. If 'owner' is not present, it sets the 'owner' attribute of the 'Project' instance to None.

Example project data causing the error:
```
{'id': 'xxxxxxxxxxxxxxxx', 'name': "Read-only Project", 'lastUpdated': '2023-09-06Txx:xx:xx.xxxZ', 'lastUpdatedBy': None, 'accessLevel': 'readOnly', 'source': 'token', 'archived': False, 'trashed': False}
```

This fix ensures that the 'from_data' method handles the case when the 'owner' attribute is missing, preventing the KeyError and enabling proper creation of 'Project' instances.