### PR TITLE
Add --host param to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,16 @@ with io.open("path/to/a/new/file", "w+") as f:
 ## Using the CLI
 The CLI provides a way to access Overleaf from the shell.
 To get started, run `pyoverleaf --help` to list available commands and their arguments.
+If you want to access your own Overleaf instance, you may set an environment variable `OVERLEAF_INSTANCE` 
+or specify it in each call appending `--host HOST`.  
 
 ### Listing projects and files
 ```bash
 # Listing projects
 pyoverleaf ls
+
+# Listing projects of your own instance
+pyoverleaf ls --host overleaf.my-host.com
 
 # Listing project files
 pyoverleaf ls project-name

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ with io.open("path/to/a/new/file", "w+") as f:
 ## Using the CLI
 The CLI provides a way to access Overleaf from the shell.
 To get started, run `pyoverleaf --help` to list available commands and their arguments.
-If you want to access your own Overleaf instance, you may set an environment variable `PYOVERLEAF_INSTANCE` 
+If you want to access your own Overleaf instance, you may set an environment variable `PYOVERLEAF_HOST` 
 or specify it in each call appending `--host HOST`.  
 
 ### Listing projects and files

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ with io.open("path/to/a/new/file", "w+") as f:
 ## Using the CLI
 The CLI provides a way to access Overleaf from the shell.
 To get started, run `pyoverleaf --help` to list available commands and their arguments.
-If you want to access your own Overleaf instance, you may set an environment variable `OVERLEAF_INSTANCE` 
+If you want to access your own Overleaf instance, you may set an environment variable `PYOVERLEAF_INSTANCE` 
 or specify it in each call appending `--host HOST`.  
 
 ### Listing projects and files

--- a/pyoverleaf/__main__.py
+++ b/pyoverleaf/__main__.py
@@ -40,10 +40,8 @@ def list_projects_and_files(path, host):
     api.login_from_browser()
     projects = api.get_projects()
     if not path or path in {".", "/"}:
-        print("Listing overleaf projects from %s\n" % host)
         print("\n".join(project.name for project in projects))
     else:
-        print("Listing files in project \"%s\" from %s\n" % (path, host))
         if path.startswith("/"):
             path = path[1:]
         project, *path = path.split("/", 1)

--- a/pyoverleaf/__main__.py
+++ b/pyoverleaf/__main__.py
@@ -3,6 +3,8 @@ import sys
 import click
 from . import Api, ProjectIO
 
+def _host_option(func):
+    return click.option("--host", default="overleaf.com", envvar="OVERLEAF_INSTANCE", help="The domain of the overleaf instance. If not given, the value of env var OVERLEAF_INSTANCE, else default overleaf.com." )(func)
 
 def _get_io_and_path(api, path):
     if "/" not in path:
@@ -32,13 +34,16 @@ def main():
 
 @main.command("ls", help="List projects or files in a project")
 @click.argument("path", type=str, default=".")
-def list_projects_and_files(path):
-    api = Api()
+@_host_option
+def list_projects_and_files(path, host):
+    api = Api(host=host)
     api.login_from_browser()
     projects = api.get_projects()
     if not path or path in {".", "/"}:
+        print("Listing overleaf projects from %s\n" % host)
         print("\n".join(project.name for project in projects))
     else:
+        print("Listing files in project \"%s\" from %s\n" % (path, host))
         if path.startswith("/"):
             path = path[1:]
         project, *path = path.split("/", 1)
@@ -59,9 +64,10 @@ def list_projects_and_files(path):
 
 @main.command("mkdir", help="Create a directory in a project")
 @click.option("-p", "--parents", is_flag=True, help="Create parent directories if they don't exist.")
+@_host_option
 @click.argument("path", type=str)
-def make_directory(path, parents):
-    api = Api()
+def make_directory(path, parents, host):
+    api = Api(host=host)
     api.login_from_browser()
     io, path = _get_io_and_path(api, path)
     io.mkdir(path, parents=parents, exist_ok=parents)
@@ -69,8 +75,9 @@ def make_directory(path, parents):
 
 @main.command("read", help="Reads the file in a project and writes to the standard output")
 @click.argument("path", type=str)
-def read(path):
-    api = Api()
+@_host_option
+def read(path, host):
+    api = Api(host=host)
     api.login_from_browser()
     io, path = _get_io_and_path(api, path)
     with io.open(path, "rb") as f:
@@ -78,8 +85,9 @@ def read(path):
 
 @main.command("write", help="Reads the standard input and writes to the file in a project")
 @click.argument("path", type=str)
-def write(path):
-    api = Api()
+@_host_option
+def write(path, host):
+    api = Api(host=host)
     api.login_from_browser()
     io, path = _get_io_and_path(api, path)
     with io.open(path, "wb+") as f:
@@ -87,8 +95,9 @@ def write(path):
 
 @main.command("rm", help="Remove file or folder from a project")
 @click.argument("path", type=str)
-def remove(path):
-    api = Api()
+@_host_option
+def remove(path, host):
+    api = Api(host=host)
     api.login_from_browser()
     io, path = _get_io_and_path(api, path)
     io.remove(path)
@@ -96,8 +105,9 @@ def remove(path):
 @main.command("download-project", help="Download project as a zip file to the specified path.")
 @click.argument("project", type=str)
 @click.argument("output_path", type=str)
-def download_project(project, output_path):
-    api = Api()
+@_host_option
+def download_project(project, output_path, host):
+    api = Api(host=host)
     api.login_from_browser()
     projects = api.get_projects()
     project_id = None

--- a/pyoverleaf/__main__.py
+++ b/pyoverleaf/__main__.py
@@ -4,7 +4,7 @@ import click
 from . import Api, ProjectIO
 
 def _host_option(func):
-    return click.option("--host", default="overleaf.com", envvar="OVERLEAF_INSTANCE", help="The domain of the overleaf instance. If not given, the value of env var OVERLEAF_INSTANCE, else default overleaf.com." )(func)
+    return click.option("--host", default="overleaf.com", envvar="PYOVERLEAF_INSTANCE", help="The domain of the overleaf instance. If not given, the value of env var OVERLEAF_INSTANCE, else default overleaf.com." )(func)
 
 def _get_io_and_path(api, path):
     if "/" not in path:

--- a/pyoverleaf/__main__.py
+++ b/pyoverleaf/__main__.py
@@ -4,7 +4,7 @@ import click
 from . import Api, ProjectIO
 
 def _host_option(func):
-    return click.option("--host", default="overleaf.com", envvar="PYOVERLEAF_INSTANCE", help="The domain of the overleaf instance. If not given, the value of env var OVERLEAF_INSTANCE, else default overleaf.com." )(func)
+    return click.option("--host", default="overleaf.com", envvar="PYOVERLEAF_HOST", help="The domain of the overleaf instance. If not given, the value of env var PYOVERLEAF_HOST, else default overleaf.com." )(func)
 
 def _get_io_and_path(api, path):
     if "/" not in path:

--- a/pyoverleaf/_webapi.py
+++ b/pyoverleaf/_webapi.py
@@ -371,7 +371,10 @@ class Api:
         """
 
     def login_from_cookies(self, cookies):
-        dot_host = f".{self._host.removeprefix('www.')}"
+        dot_host = self._host
+        if dot_host[:4] == 'www.':
+            dot_host = f".{self._host.removeprefix('www.')}"
+
         if not isinstance(cookies, cookielib.CookieJar):
             assert isinstance(cookies, dict)
             cookies_jar = cookielib.CookieJar()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Overleaf API and simple CLI"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["overleaf", "api"]
-license = {text = "MIT"}
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "Overleaf API and simple CLI"
 readme = "README.md"
 requires-python = ">=3.8"
 keywords = ["overleaf", "api"]
-license = "MIT"
+license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
This pull request adds a --host param to the CLI which allows to use it also easily with your instance.
So far, the API had the possibility to use the param as of #5, but not in the CLI interface.

There are three options, with descending importance:
- Specify --host overleaf.your-host.com, which overrides default value and env value
- Set an ENV var PYOVERLEAF_HOST, which overrides the default value
- Do not specify anything; in that case we keep overleaf.com

Also this fixes #11 and takes the suggested solution in the issue, as I also came to that problem.
~~Also I got a hint while building that the license format changes, so I did that.~~ (moved to #14)
And I also added small hints in the README, how to use other instances.