### PR TITLE
Update minimum python to 3.9 due to build no longer supporting py3.8

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.9, "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
           pip install pytest pytest-cov
       - name: Test with pytest
         run:
-          PYTHONHASHSEED=0 pytest --ignore docs --cov=pyoverleaf ${{ ((matrix.python-version == '3.7') && '--ignore-glob "tests/*_py38_test.py"') || '' }} --cov-report=xml --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
+          PYTHONHASHSEED=0 pytest --ignore docs --cov=pyoverleaf --cov-report=xml --doctest-modules --junitxml=junit/test-results-${{ matrix.python-version }}.xml
       # - name: Upload coverage to Codecov
       #   uses: codecov/codecov-action@v2
       #   with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0.0", "setuptools_scm[toml]>=8.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Overleaf API and simple CLI"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["overleaf", "api"]
 license = "MIT"
 classifiers = [


### PR DESCRIPTION
Update minimum python to 3.9 as the build library no longer supports py3.8 and therefore the build fails due to the update of the license (see #14)

Also include the current python versions in the test.